### PR TITLE
Add recommender call to API

### DIFF
--- a/core/src/main/java/com/ibm/drl/hbcp/parser/JSONRefParser.java
+++ b/core/src/main/java/com/ibm/drl/hbcp/parser/JSONRefParser.java
@@ -20,6 +20,7 @@ import com.ibm.drl.hbcp.util.FileUtils;
 import com.ibm.drl.hbcp.util.ParsingUtils;
 import com.ibm.drl.hbcp.util.Props;
 import lombok.Data;
+import net.arnx.jsonic.JSON;
 import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -486,9 +487,24 @@ public class JSONRefParser implements JSONRefParserBase {
         System.out.println(nameNumberValues.size());
     }
 
+    public static void displayReachAttributes() throws IOException {
+        JSONRefParser parser = new JSONRefParser(new File("../data/jsons/All_annotations_512papers_05March20.json"));
+        for (AnnotatedAttributeValuePair avp : parser.getAttributeValuePairs()) {
+            if (avp.getAttribute().getName().contains(" analysed")) {
+                System.out.println("For doc: " + avp.getDocName());
+                System.out.println(avp);
+            }
+        }
+    }
+
     public static void countAttributes() throws IOException {
-        JSONRefParser parser = new JSONRefParser(new File("data/jsons/All_annotations_512papers_05March20.json"));
+        JSONRefParser parser = new JSONRefParser(new File("../data/jsons/All_annotations_512papers_05March20.json"));
         System.out.println("Attribute count: " + parser.getAttributeValuePairs().getAllAttributeIds().size());
+    }
+
+    public static void countAttributesPA() throws IOException {
+        JSONRefParser parser = new JSONRefParser(new File("../data/jsons/PhysicalActivity Sprint1ArmsAnd Prioritised47Papers.json"));
+        System.out.println("Attribute count for PA: " + parser.getAttributeValuePairs().getAllAttributeIds().size());
     }
 
     public static void mainTableGrammar() throws IOException {
@@ -519,7 +535,9 @@ public class JSONRefParser implements JSONRefParserBase {
     }
 
     public static void main(String[] args) throws IOException {
-        mainTableGrammar();
+        //mainTableGrammar();
         //countAttributes();
+        //countAttributesPA();
+        displayReachAttributes();
     }
 }

--- a/core/src/main/java/com/ibm/drl/hbcp/predictor/api/RecommendedIntervention.java
+++ b/core/src/main/java/com/ibm/drl/hbcp/predictor/api/RecommendedIntervention.java
@@ -1,0 +1,26 @@
+package com.ibm.drl.hbcp.predictor.api;
+
+import lombok.Value;
+
+import javax.json.Json;
+import javax.json.JsonValue;
+import java.util.List;
+
+@Value
+public class RecommendedIntervention implements Jsonable {
+
+    /** The IDs of the Behavior-Change techniques making up the intervention. */
+    List<String> bctIds;
+    /** Prediction result: predicted outcome value and confidence */
+    double predictedValue;
+    double confidence;
+
+    @Override
+    public JsonValue toJson() {
+        return Json.createObjectBuilder()
+                .add("intervention", Jsonable.getJsonArrayFromStrings(bctIds))
+                .add("predictedValue", predictedValue)
+                .add("confidence", confidence)
+                .build();
+    }
+}

--- a/core/src/main/java/com/ibm/drl/hbcp/predictor/api/RecommendedInterventions.java
+++ b/core/src/main/java/com/ibm/drl/hbcp/predictor/api/RecommendedInterventions.java
@@ -1,0 +1,123 @@
+package com.ibm.drl.hbcp.predictor.api;
+
+import com.google.common.collect.ConcurrentHashMultiset;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.Multisets;
+import com.ibm.drl.hbcp.core.attributes.AttributeType;
+import com.ibm.drl.hbcp.core.attributes.AttributeValuePair;
+import com.ibm.drl.hbcp.core.attributes.collection.AttributeValueCollection;
+import com.ibm.drl.hbcp.parser.AnnotatedAttributeValuePair;
+import com.ibm.drl.hbcp.parser.Attributes;
+import com.ibm.drl.hbcp.parser.JSONRefParser;
+import com.ibm.drl.hbcp.util.Props;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Draw from the smoking cessation annotations to provide the most frequent intervention (as a set of BCTs) reported on
+ * @author mgleize
+ */
+public class RecommendedInterventions {
+
+    private RecommendedInterventions() throws IOException {
+        mostFrequentInterventions = getMostFrequentInterventionsInAnnotations();
+    }
+
+    // sets of BCT IDs
+    private final List<Set<String>> mostFrequentInterventions;
+
+    /** Returns at most 'max' of the interventions sorted by descending frequency */
+    public List<Set<String>> getTopKMostFrequentInterventions(int max) {
+        return mostFrequentInterventions.stream()
+                .limit(max)
+                .collect(Collectors.toList());
+    }
+
+    /** Transform a BC scenario with a set of all possible BCTs allowed, into a set of recommended scenarios with reasonable
+     * combinations of BCTs taken from that set. */
+    public List<Set<String>> getRecommendedInterventions(List<AttributeValuePair> possibleScenarios, int max) {
+        // extract the BCTs from the possibleScenarios, they are what is "allowed" by the user
+        Set<String> allowedBctIds = possibleScenarios.stream()
+                .filter(avp -> avp.getAttribute().getType() == AttributeType.INTERVENTION)
+                .map(avp -> avp.getAttribute().getId())
+                .collect(Collectors.toSet());
+        // filter pre-computed recommended interventions based on this
+        return mostFrequentInterventions.stream()
+                .filter(allowedBctIds::containsAll)
+                .limit(max)
+                // no need to sort, they're already sorted
+                .collect(Collectors.toList());
+    }
+
+    /** Transform a BC scenario with a set of all possible BCTs allowed, into a set of recommended scenarios with reasonable
+     * combinations of BCTs taken from that set. */
+    public List<List<AttributeValuePair>> getRecommendedScenarios(List<AttributeValuePair> possibleScenarios, int max) {
+        // get recommended compatible scenarios
+        List<Set<String>> recommendedInterventions = getRecommendedInterventions(possibleScenarios, max);
+        // for each of the recommended intervention, build a new complete scenario
+        List<AttributeValuePair> nonInterventionAvps = possibleScenarios.stream()
+                .filter(avp -> avp.getAttribute().getType() != AttributeType.INTERVENTION)
+                .collect(Collectors.toList());
+        List<List<AttributeValuePair>> res = new ArrayList<>();
+        for (Set<String> recommendedIntervention : recommendedInterventions) {
+            List<AttributeValuePair> recommendedScenario = new ArrayList<>(nonInterventionAvps);
+            recommendedScenario.addAll(recommendedIntervention.stream()
+                    .map(bctId -> new AttributeValuePair(Attributes.get().getFromId(bctId), "1"))
+                    .collect(Collectors.toList()));
+            res.add(recommendedScenario);
+        }
+        return res;
+    }
+
+    private static List<Set<String>> getMostFrequentInterventionsInAnnotations() throws IOException {
+        // read annotations
+        AttributeValueCollection<AnnotatedAttributeValuePair> annotations = new JSONRefParser(Props.loadProperties())
+                .getAttributeValuePairs()
+                // do not forget to distribute the empty arms here
+                .distributeEmptyArm();
+        // get all interventions (through their ID sets) and their frequency
+        Multiset<Set<String>> res = ConcurrentHashMultiset.create();
+        for (String docName : annotations.getDocNames()) {
+            for (Multiset<AnnotatedAttributeValuePair> armifiedAvps : annotations.getArmifiedPairsInDoc(docName).values()) {
+                Set<String> bctIds = armifiedAvps.stream()
+                        .filter(avp -> avp.getAttribute().getType() == AttributeType.INTERVENTION)
+                        .map(avp -> avp.getAttribute().getId())
+                        .collect(Collectors.toSet());
+                if (!bctIds.isEmpty())
+                    res.add(bctIds);
+            }
+        }
+        // sort by frequency
+        ImmutableMultiset<Set<String>> sortedRes = Multisets.copyHighestCountFirst(res);
+        return new ArrayList<>(sortedRes.elementSet());
+    }
+
+    // implements the lazy-initialization thread-safe singleton pattern
+    private static class LazyHolder {
+        private static RecommendedInterventions buildInterventions() {
+            try {
+                return new RecommendedInterventions();
+            } catch (IOException e) {
+                e.printStackTrace();
+                throw new RuntimeException("IOException when lazy-initializing singleton RecommendedInterventions", e);
+            }
+        }
+        private static final RecommendedInterventions INSTANCE = buildInterventions();
+    }
+
+    /** Returns the Attributes collection for the JSON annotation file defined in the default properties */
+    public static RecommendedInterventions get() {
+        return RecommendedInterventions.LazyHolder.INSTANCE;
+    }
+
+    public static void main(String[] args) {
+        for (Set<String> intervention : RecommendedInterventions.get().getTopKMostFrequentInterventions(20)) {
+            System.out.println(intervention);
+        }
+    }
+}

--- a/prediction-experiments/python-nb/ov-predict/src/api/predict_app_outcome_and_confidence.py
+++ b/prediction-experiments/python-nb/ov-predict/src/api/predict_app_outcome_and_confidence.py
@@ -23,7 +23,7 @@ app = Flask(__name__)
 inpH = init_embedding(EMBFILE)
 
 
-@app.route('/')
+@app.route('/hbcp/api/v1.0/predict/')
 def home():
     return "This is the prediction API."
 
@@ -33,6 +33,36 @@ def preprocess_request(data):
     pp_string = data.replace("-", " ")
 
     return pp_string
+
+
+@app.route('/hbcp/api/v1.0/predict/outcome/batch/', methods=['POST'])
+def outcome_batch():
+    # load models
+    print ("#word-nodes = {}".format(len(inpH.pre_emb)))
+    trained_model = init_model(inpH)  # do this everytime...
+    trained_model_for_mc = init_model(inpH, saved_model_wts_file=MC_MODEL_WT_FILE,
+                                      num_classes=7)  # load the mc model for getting confidences
+    # expected data is a query string per line of body, parse it
+    queries = request.data.decode('UTF-8').splitlines()
+    results = []
+    for query in queries:
+        pp_data = preprocess_request(query)
+        print ("pp_data = {}".format(pp_data))
+        #Reshape the vectors... this is not needed as we're using a merged vocab
+        #print ("#Reshaping the original w/o context vectors word-nodes")
+        #inpH.modifyW2V(pp_data)
+        predicted_val = predict_outcome_with_dynamic_vocabchange(inpH, trained_model, pp_data, NODEVEC_DIM)
+        confidence = predict_confidence(inpH, trained_model_for_mc, pp_data, NODEVEC_DIM)
+        result = {}
+        result['value'] = str(predicted_val)
+        result['conf'] = str(confidence)
+        results.append(result)
+    # clear Keras session
+    k.clear_session()
+    # prepare top level JSON object
+    retmap = {'results': results}
+    return json.dumps(retmap)
+
 
 @app.route('/hbcp/api/v1.0/predict/outcome/<string:data>', methods=['GET'])
 def outcome(data):
@@ -58,6 +88,7 @@ def outcome(data):
     retmap['conf'] = str(confidence) 
 
     return json.dumps(retmap)
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
The /api/predict/recommend/ predicts a set of possible interventions with their associated predicted quitrate. Leverages a batch call to the Python prediction API.